### PR TITLE
Fix: Delete uploaded files when records are removed

### DIFF
--- a/models/Record.php
+++ b/models/Record.php
@@ -28,10 +28,11 @@
             return $this->filterGroups();
         }
 
-        public function beforeDelete()
-        {
-            foreach ($this->attachments as $file) {
-                $file->delete();
+        public function beforeDelete() {
+            if ($this->files && $this->files->count() > 0) {
+                foreach ($this->files as $file) {
+                    $file->delete();
+                }
             }
         }
 

--- a/models/Record.php
+++ b/models/Record.php
@@ -28,6 +28,13 @@
             return $this->filterGroups();
         }
 
+        public function beforeDelete()
+        {
+            foreach ($this->attachments as $file) {
+                $file->delete();
+            }
+        }
+
     }
 
 ?>


### PR DESCRIPTION
This PR fixes an issue where uploaded files are not deleted when records are removed from the backend.  
- Added a `beforeDelete` method in the `Record.php` model to delete related attachments.  
- Tested and verified functionality.

Resolves #27.